### PR TITLE
Fix vWii Channel View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ usbloader_gx/
 /source/svnrev.c
 /usbloader_gx.zip
 /wiiload
+/output

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 FROM debian:buster as usbloader
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 RUN apt-get update -y && apt-get install -y \ 
-    xz-utils make git
+    xz-utils make git zip
 
 ADD https://wii.leseratte10.de/devkitPro/file.php/devkitPPC-r41-2-linux_x86_64.pkg.tar.xz /
 ADD https://wii.leseratte10.de/devkitPro/file.php/libogc-2.3.1-1-any.pkg.tar.xz /
@@ -31,9 +31,11 @@ ENV DEVKITPPC=/devkitpro/devkitPPC
 # Now we have a container that has the dev environment set up. 
 # Copy current folder into container, then compile
 COPY . /projectroot/
-RUN cd /projectroot && make
+RUN cd /projectroot && make clean && make -j8 package
 
 
 # Copy the DOL and ELF out of the container
 FROM scratch AS export-stage
-COPY --from=usbloader /projectroot/boot.* /
+COPY --from=usbloader /projectroot/boot.* / 
+COPY --from=usbloader /projectroot/usbloader_gx /
+COPY --from=usbloader /projectroot/usbloader_gx.zip /

--- a/Makefile
+++ b/Makefile
@@ -177,14 +177,21 @@ clean:
 	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol usbloader_gx.zip usbloader_gx
 
 #---------------------------------------------------------------------------------
-deploy:
+
+package:
 	$(MAKE)
-	@echo Deploying...
+	@echo Packaging...
 	@[ -d usbloader_gx ] || mkdir -p usbloader_gx
 	@cp $(TARGET).dol usbloader_gx/
 	@cp HBC/icon.png usbloader_gx/
 	@cp HBC/meta.xml usbloader_gx/
 	@zip usbloader_gx.zip usbloader_gx/*
+
+#---------------------------------------------------------------------------------
+
+deploy:
+	$(MAKE) package	
+	@echo Deploying...
 	wiiload usbloader_gx.zip
 
 #---------------------------------------------------------------------------------

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -60,8 +60,8 @@ bool SystemMenuResources::Init()
     // Priiloader moves some system resources that we rely on from index 1 to index 9.
     // In doing this it creates a 10th index (9) to contain the moved resources.
     // If priiloader is installed, we need to look for content at index 9 instead of index 1.
-    bool hasVWiiPriiloader = p_tmd->num_contents == 10;
-    u16 targetIndex = hasVWiiPriiloader ? 9 : 1;
+	bool hasVWiiPriiloader = p_tmd->num_contents == 10;
+	u16 targetIndex = hasVWiiPriiloader ? 9 : 1;
 
 	for( u16 i = 0; i < p_tmd->num_contents; i++ )
 	{

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -70,13 +70,14 @@ bool SystemMenuResources::Init()
 			idx = i;
 			break;
 		}
-
 	}
+
 	if( idx == 0xffff )
 	{
 		gprintf( "SM main resource not found\n" );
 		return false;
 	}
+
 	// build file path
 	char path[ ISFS_MAXPATH ]__attribute__((aligned( 32 )));
 	sprintf(path, "/title/00000001/00000002/content/%08x.app", (unsigned int)contents[ idx ].cid);

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -57,9 +57,9 @@ bool SystemMenuResources::Init()
 	u16 idx = 0xffff;
 	tmd_content *contents = TMD_CONTENTS( p_tmd );
 
-    // Priiloader moves some system resources that we rely on from index 1 to index 9.
-    // In doing this it creates a 10th index (9) to contain the moved resources.
-    // If priiloader is installed, we need to look for content at index 9 instead of index 1.
+	// Priiloader moves some system resources that we rely on from index 1 to index 9.
+	// In doing this it creates a 10th index (9) to contain the moved resources.
+	// If priiloader is installed, we need to look for content at index 9 instead of index 1.
 	bool hasVWiiPriiloader = p_tmd->num_contents == 10;
 	u16 targetIndex = hasVWiiPriiloader ? 9 : 1;
 

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -56,13 +56,26 @@ bool SystemMenuResources::Init()
 	// determine resource cid
 	u16 idx = 0xffff;
 	tmd_content *contents = TMD_CONTENTS( p_tmd );
+
 	for( u16 i = 0; i < p_tmd->num_contents; i++ )
 	{
+        // If original wii, or vWii with no priiloader, index 1 
+        // should have the system menu resources that we need.
+        // Don't break though, because vWii with priiloader
+        // will require a different index.
 		if( contents[ i ].index == 1 )
 		{
 			idx = i;
-			break;
 		}
+
+        // Priiloader moves system menu resources to index 9. 
+        // If we find an index 9, we definitely have priiloader
+        // and we're on vWii, so use index 9 and stop searching.
+		if( contents[ i ].index == 9 )
+        { 
+            idx = i;
+            break;
+        }
 	}
 	if( idx == 0xffff )
 	{
@@ -71,7 +84,9 @@ bool SystemMenuResources::Init()
 	}
 	// build file path
 	char path[ ISFS_MAXPATH ]__attribute__((aligned( 32 )));
-	sprintf( path, "/title/00000001/00000002/content/%08x.app", (unsigned int)contents[ idx ].cid );
+	sprintf( 
+            path, 
+            "/title/00000001/00000002/content/%08x.app", (unsigned int)contents[ idx ].cid );
 
 	// get resource archive
 	u8* resourceArc = NULL;

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -57,25 +57,20 @@ bool SystemMenuResources::Init()
 	u16 idx = 0xffff;
 	tmd_content *contents = TMD_CONTENTS( p_tmd );
 
+    // Priiloader moves some system resources that we rely on from index 1 to index 9.
+    // In doing this it creates a 10th index (9) to contain the moved resources.
+    // If priiloader is installed, we need to look for content at index 9 instead of index 1.
+    bool hasVWiiPriiloader = p_tmd->num_contents == 10;
+    u16 targetIndex = hasVWiiPriiloader ? 9 : 1;
+
 	for( u16 i = 0; i < p_tmd->num_contents; i++ )
 	{
-        // If original wii, or vWii with no priiloader, index 1 
-        // should have the system menu resources that we need.
-        // Don't break though, because vWii with priiloader
-        // will require a different index.
-		if( contents[ i ].index == 1 )
+		if( contents[ i ].index == targetIndex )
 		{
 			idx = i;
+			break;
 		}
 
-        // Priiloader moves system menu resources to index 9. 
-        // If we find an index 9, we definitely have priiloader
-        // and we're on vWii, so use index 9 and stop searching.
-		if( contents[ i ].index == 9 )
-        { 
-            idx = i;
-            break;
-        }
 	}
 	if( idx == 0xffff )
 	{

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -79,9 +79,7 @@ bool SystemMenuResources::Init()
 	}
 	// build file path
 	char path[ ISFS_MAXPATH ]__attribute__((aligned( 32 )));
-	sprintf( 
-            path, 
-            "/title/00000001/00000002/content/%08x.app", (unsigned int)contents[ idx ].cid );
+	sprintf(path, "/title/00000001/00000002/content/%08x.app", (unsigned int)contents[ idx ].cid);
 
 	// get resource archive
 	u8* resourceArc = NULL;


### PR DESCRIPTION
This first performs a presumptive check for index 1 containing the system menu resources, but continues iterating until it sees index 9. Index 9 contains the system menu resources when priiloader is installed on vWii.  This should be fine even if index 9 is not present (like on normal wii, or vWii without priiloader) because there's not going to be many indexes... I think

[Fixed in r1282 on my fork](https://github.com/Jacoby6000/usbloadergx/releases/tag/v3.0-1282)